### PR TITLE
fix: global signer deprecated

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -298,12 +298,12 @@ export async function getValidatorState(
 
 export async function requestFaucet(
   aptosClient: AptosClient,
-  faucetClient: FaucetClient,
   faucetUrl: string,
   pubkey: string,
 ): Promise<any> {
 
-  const url = `${faucetUrl}/mint?&address=${pubkey}`;
+  const url = `${faucetUrl}/mint?address=${pubkey}`;
+  console.log(url);
   let txns = [];
   try {
     const response = await axios.post(url, {});
@@ -344,13 +344,11 @@ export async function requestFaucetWithGlobalSigner(
   Promise.all([
     await requestFaucet(
       aptosClient,
-      faucetClient,
       faucetUrl,
       PUBLIC_KEY,
     ),
     await requestFaucet(
       aptosClient,
-      faucetClient,
       faucetUrl,
       PUBLIC_KEY,
     )

--- a/src/pages/LandingPage/Index.tsx
+++ b/src/pages/LandingPage/Index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { requestFaucetWithGlobalSigner, mevmRequestFaucet, m2RequestFaucet } from "../../api";
+import { requestFaucet, mevmRequestFaucet, m2RequestFaucet } from "../../api";
 import { AptosClient, FaucetClient, CoinClient } from "aptos";
 import Chain from "../../components/Chain";
 
@@ -15,10 +15,8 @@ export default function LandingPage() {
 
 
   const m1FaucetRequest = async (address: string) => {
-    return requestFaucetWithGlobalSigner(
+    return requestFaucet(
       aptosClient,
-      faucetClient,
-      coinClient,
       M1_FAUCET_URL,
       address
     );


### PR DESCRIPTION
M1 faucet call was dependent on a Global Signer construct. It was giving us an error at the current deployment.
Issue has been resolved, we are turning to solely making a post request to M1 faucet.